### PR TITLE
Fix regex for define

### DIFF
--- a/syntaxes/cql.tmLanguage.json
+++ b/syntaxes/cql.tmLanguage.json
@@ -78,7 +78,7 @@
 		"name": "keyword.declarations.cql"
 	  },
 	  {
-		"begin": "\\b(define( function)?) (\".+?\")",
+		"begin": "\\b(define( function)?) ((\".*\")|(`.*`)|([^\"`\\s]+))",
 		"beginCaptures": {
 		  "1": {
 			"name": "keyword.declarations.cql"


### PR DESCRIPTION
"define" and "define function" can be followed by a non-quoted string
without spaces, a double-quoted string with or without spaces, or a
backtick-quoted string with or without spaces (as of CQL 1.3).

The previous regex assumed double-quotes would always be present.
This fixes that assumption to allow other valid possibilities.